### PR TITLE
UI Fixes

### DIFF
--- a/classes/class-bpbu-admin-list-tables.php
+++ b/classes/class-bpbu-admin-list-tables.php
@@ -122,8 +122,11 @@ class BPBU_Admin_List_Tables extends BPBU_Admin {
 			$hook .= '-network';
 		}
 
-		// Add the block users admin loader.
-		add_action( "load-{$hook}", array( $this, 'admin_load' ) );
+		if( isset( $hook ) ) {
+			
+			// Add the block users admin loader.
+			add_action( "load-{$hook}", array( $this, 'admin_load' ) );
+		}
 	}
 
 	/**

--- a/classes/class-bpbu-component.php
+++ b/classes/class-bpbu-component.php
@@ -248,7 +248,7 @@ if ( class_exists( 'BP_Component' ) ) {
 				'parent' => $menu_id,
 				'id'     => $menu_id . '-block-user',
 				'title'  => __( 'Block User', 'bp-block-users' ),
-				'href'   => trailingslashit( bp_loggedin_user_domain() . bp_get_settings_slug() ) . 'block-user/',
+				'href'   => trailingslashit( bp_displayed_user_domain() . bp_get_settings_slug() ) . 'block-user/',
 			) );
 		}
 

--- a/templates/buddypress/members/single/settings/block-user.php
+++ b/templates/buddypress/members/single/settings/block-user.php
@@ -14,8 +14,8 @@ do_action( 'bp_before_member_settings_template' ); ?>
 	 */
 	do_action( 'bp_members_block_user_before_submit' ); ?>
 
-	<label for="block-user">
-		<input type="checkbox" name="block-user" id="block-user" value="1" <?php checked( BPBU_User::is_blocked( bp_displayed_user_id() ) ); ?> />
+	<label for="block-user-checkbox">
+		<input type="checkbox" name="block-user" id="block-user-checkbox" value="1" <?php checked( BPBU_User::is_blocked( bp_displayed_user_id() ) ); ?> />
 		 <?php esc_html_e( 'Block this member?', 'bp-block-users' ); ?>
 	</label>
 


### PR DESCRIPTION
Fixing undefined variable warning in admin
Fixing admin bar link going to logged in user instead of displayed user ([original report](https://wordpress.org/support/topic/blocking-a-user-does-not-work-in-frontend-mode/))
Fixing checkbox having a duplicate ID