### PR TITLE
Add block reasoning functionality

### DIFF
--- a/classes/class-bpbu-admin-profile.php
+++ b/classes/class-bpbu-admin-profile.php
@@ -117,6 +117,13 @@ class BPBU_Admin_Profile extends BPBU_Admin {
 					</select>
 				</td>
 			</tr></tbody>
+			<tbody><tr>
+				<th scope="row"><?php esc_html_e( 'Reason', 'bp-block-users' ); ?></th>
+				<td>
+					<label for="block-user-reason" class="screen-reader-text"><?php esc_html_e( 'The reason the user is being blocked.', 'bp-block-users' ); ?></label>
+					<textarea type="text" name="block-user-reason" id="block-user-reason" value="" size="3" />
+				</td>
+			</tr></tbody>
 		</table>
 
 		<?php


### PR DESCRIPTION
This PR will add a form in the appropriate places to store the reason a user is being blocked. This information is then retrieved and listed out for admins to review later when they unblock, or block again.